### PR TITLE
Update pre-work for October cohorts

### DIFF
--- a/0ea_daily_schedule.md
+++ b/0ea_daily_schedule.md
@@ -24,7 +24,39 @@ In this lesson, we detail what the typical daily schedule for students usually l
 
 **4:30 pm** The day will end with a retrospective in your dev team. Use this time to show what you worked on, discuss your struggles, give a shout-out, talk what you want to do better tomorrow, share what you enjoyed the most, and so on.
 
-### [Part-Time Students — Sundays](#part-time-students-sundays)
+### [Part-Time Day-time (mornings) Students](#part-time-students-weekdays)
+
+**7:45 am.** Log onto Discord or arrive on campus. Log into your attendance, find your dev team, find a pair, and look over the lessons for the day.
+
+**8:00 am.** Your Dev Team Scrum meeting begins. Make sure that everyone is present and connected (if online) before getting started. If you haven't found a pair, find one during your Dev Team Scrum. Everyone in the group will take a moment to answer each of the following:
+
+1. What did you work on in the previous class session or over the weekend?
+2. What are you working on today?
+3. What blocks are you facing? Is anything standing in your way?
+
+**8:15 am.** Your Cohort Scrum meeting begins. This meeting is led by your instructor and includes your entire cohort. If you are online, your instructor will share the meeting link for Scrum with you. It may take a little time to enter the video call as instructors get set up. If you are in person, your instructor will call you to join Scrum. Scrum often includes important announcements and instructions as well as discussion about key concepts, so it's important to attend.
+
+**8:30 am.** Start pair programming for the evening 
+
+**11:40 am.** The class will end with a retrospective in your dev team. Use this time to show what you worked on, discuss your struggles, give a shout-out, talk what you want to do better tomorrow, share what you enjoyed the most, and so on.
+
+### [Part-Time Day-time (afternoons) Students](#part-time-students-weekdays)
+
+**12:45 pm.** Log onto Discord or arrive on campus. Log into your attendance, find your dev team, find a pair, and look over the lessons for the day.
+
+**1:00 pm.** Your Dev Team Scrum meeting begins. Make sure that everyone is present and connected (if online) before getting started. If you haven't found a pair, find one during your Dev Team Scrum. Everyone in the group will take a moment to answer each of the following:
+
+1. What did you work on in the previous class session or over the weekend?
+2. What are you working on today?
+3. What blocks are you facing? Is anything standing in your way?
+
+**1:15 pm.** Your Cohort Scrum meeting begins. This meeting is led by your instructor and includes your entire cohort. If you are online, your instructor will share the meeting link for Scrum with you. It may take a little time to enter the video call as instructors get set up. If you are in person, your instructor will call you to join Scrum. Scrum often includes important announcements and instructions as well as discussion about key concepts, so it's important to attend.
+
+**1:30 pm.** Start pair programming for the evening 
+
+**4:40 pm.** The class will end with a retrospective in your dev team. Use this time to show what you worked on, discuss your struggles, give a shout-out, talk what you want to do better tomorrow, share what you enjoyed the most, and so on.
+
+### [Part-Time Evening Students — Sundays](#part-time-students-sundays)
 
 **9:00 am.** Log onto Discord or arrive on campus. Log into your attendance, find your dev team, find a pair, and look over the lessons for the day.
 
@@ -44,7 +76,7 @@ In this lesson, we detail what the typical daily schedule for students usually l
 
 **4:30 pm** The day will end with a half hour retrospective in your dev team. Use this time to show what you worked on, discuss your struggles, give a shout-out, talk what you want to do better tomorrow, share what you enjoyed the most, and so on.
 
-### [Part-Time Students — Weekdays](#part-time-students-weekdays)
+### [Part-Time Evening Students — Weekdays](#part-time-students-weekdays)
 
 **5:45 pm.** Log onto Discord or arrive on campus. Log into your attendance, find your dev team, find a pair, and look over the lessons for the day.
 

--- a/0f_remote_attendance_policy.md
+++ b/0f_remote_attendance_policy.md
@@ -62,7 +62,7 @@ If you either show up late to class or leave early from class, this counts as a 
 * _Tardy_ 
 * _Left Early_
 
-**For part-time students, Sundays count as two days of attendance.** 
+**For part-time evening students, Sundays count as two days of attendance.** 
 
 Your goal is to be _On Time_ every day. That said, Epicodus provides a generous amount of allowed absences for you to use for any reason.
 
@@ -76,7 +76,7 @@ Your attendance record will appear on your transcript, which will be sent to int
 
 All students are allowed a certain number of missed class days to use as needed:
 
-* Part-time students have 20 days of allowed absences throughout the entire program. 
+* Part-time (day **and* evening) students have 20 days of allowed absences throughout the entire program. 
 * Full-time students have 10 days of allowed absences throughout the entire program.
 
 Take note that if you are on a deferred payment program, you will have a different agreement with the school. If you are unsure of which payment program or agreement you have with Epicodus, please reach out to your teacher and advisor.
@@ -90,19 +90,23 @@ There are specific time windows that we expect students to sign in and sign out 
 
 ### [Sign In](#sign-in)
 
-Monday through Thursday, **full-time students** need to sign in between 7:30 am – 8:15 am. If you are not signed in by 8:15 am, you will be marked tardy for the class.
+**Full-Time Students:** Your sign-in window will be between 7:30 am - 8:15 am on weekdays, Monday through Thursday. If you are not signed in by 8:15 am, you will be marked tardy for the class.
 
-Monday through Wednesday, **part-time students** need to sign in between 5:30 pm – 6:15 pm. If you are not signed in by 6:15 pm, you will be marked tardy for the class. 
+**Part-Time Day-Time Students (mornings):** Your sign-in window will be between 7:30 am - 8:15 am on weekdays, Monday through Thursday. If you are not signed in by 8:15 am, you will be marked tardy for the class.
 
-On Sundays, **part-time students** need to sign in between 8:30 am – 9:15 am. If you are not signed in by 9:15 am, you will be marked tardy for the class. Since class time is longer and there's more content covered on Sundays, Sundays count as two attendance days.
+**Part-Time Day-Time Students (afternoons):** Your sign-in window will be between 12:30 pm - 1:15 pm on weekdays, Monday through Thursday. If you are not signed in by 1:15 pm, you will be marked tardy for the class.
+
+**Part-Time *Evening* Students:** Your sign-in window will be between 5:30 pm - 6:15 pm on weekdays, Monday through Wednesday. On Sundays, the sign-in windows is between 8:30 am – 9:15 am. If you are not signed in by 6:15 pm on weekdays, or by 9:15 am on Sundays, you will be marked tardy for the class. Since class time is longer and there's more content covered on Sundays, Sundays count as two attendance days.
 
 ### [Sign Out](#sign-out)
 
-Monday through Thursday, **full-time students** need to sign out between 4:45 pm – 5:30 pm. If you are not signed out by 5:30 pm, you will be marked as having left early for the class.
+**Full-Time Students:** Your sign-out window will be between 4:45 pm – 5:30 pm on weekdsays Monday - Thursday. If you are not signed out by 5:30 pm, you will be marked as having left early for the class.
 
-Monday through Wednesday, **part-time students** need to sign out between 8:45 pm – 9:30 pm. If you are not signed out by 9:30 pm, you will be marked as having left early for the class. 
+**Part-Time Day-Time Students (mornings):** Your sign-out window will be between 11:45 am – 12:30 pm on weekdsays Monday - Thursday. If you are not signed out by 12:30 pm, you will be marked as having left early for the class.
 
-On Sundays, **part-time students** need to sign out between 4:45 pm – 5:30 pm. If you are not signed out by 5:30 pm, you will be marked as having left early for the class. Since class time is longer and there's more content covered on Sundays, Sundays count as two attendance days.
+**Part-Time Day-Time Students (afternoons):** Your sign-out window will be between 4:45 pm – 5:30 pm on weekdsays Monday - Thursday. If you are not signed out by 5:30 pm, you will be marked as having left early for the class.
+
+**Part-Time *Evening* Students:** Your sign-out window will be between 8:30 pm - 9:15 pm on weekdays, Monday through Wednesday. On Sundays, the sign-out windows is between 4:45 am – 5:30 pm. If you are not signed out by 9:30 pm on weekdays, or by 5:30 pm on Sundays, you will be marked left early for the class. Since class time is longer and there's more content covered on Sundays, Sundays count as two attendance days.
 
 ## [Pair Feedback](#pair-feedback)
 ---

--- a/0g_curriculum_details_intro_to_programming.md
+++ b/0g_curriculum_details_intro_to_programming.md
@@ -38,7 +38,7 @@ Every lesson and exercise has a blue _Feedback_ tab at the bottom right-hand cor
 
 If the tab doesn't show immediately, you may need to scroll down the page for it to pop up. You can click the tab to open up a menu that has tools to help you leave feedback, like highlighting a section of a lesson that needs updating. This is what the window will look like after you click on the _Feedback_ tab:
 
-![Image of learnhowtoprogram.com feedback tool menu.](https://learnhowtoprogram.s3.us-west-2.amazonaws.com/usersnap-LHTP-feedback/LHTP-feedback-tool-menu.png)
+![Image of learnhowtoprogram.com feedback tool menu.](https://learnhowtoprogram.s3.us-west-2.amazonaws.com/pre-work/usersnap-feedback-example.png)
 
 If there is a lesson that really helped grow your understanding or if there is a suggestion you may have for improvement, we value your insight and hope that you will share it with us. We encourage feedback on any issue that comes up — both large and small — whether that is a typo, a passage that is confusing, or an area you feel could use clarification or any other kind of improvement. 
 

--- a/0i_preparing_for_the_first_week.md
+++ b/0i_preparing_for_the_first_week.md
@@ -7,15 +7,19 @@ We've covered a lot of ground in this section of the pre-work and we're almost d
 You'll start each new course section in this program by reading that section's objectives. The objectives are designed to give you a general sense of what you'll be covering in the section and to prepare you for that section's independent project. Here are the objectives for the first section:
 
 * Full-time students: [Git, HTML and CSS Objectives](https://new.learnhowtoprogram.com/introduction-to-programming/git-html-and-css/git-html-&-css-objectives).
-* Part-time students: [Git, HTML and CSS Objectives](https://new.learnhowtoprogram.com/introduction-to-programming-part-time/git-html-and-css/git-html-&-css-objectives)
+* Part-time Day-time students: [Git, HTML and CSS Objectives](https://new.learnhowtoprogram.com/introduction-to-programming-part-time/git-html-and-css/git-html-&-css-objectives)
+* Part-time Evening students: [Git, HTML, and CSS Objectives](https://new.learnhowtoprogram.com/introduction-to-programming-part-time-evening/git-html-and-css/git-html-&-css-objectives)
+* *Legacy* Full-time students: [Git, HTML and CSS Objectives](https://new.learnhowtoprogram.com/introduction-to-programming-classic/git-html-and-css/git-html-&-css-objectives).
 
 ## [Daily Expectations](#daily-expectations)
 
 ---
 
-In addition to the section objectives, you'll have daily expectations for the first section of the program. These expectations will help orientate you for the day and to provide clarity on any key concepts you'll need to focus on. We recommend looking over the daily expectations ahead of time (such as the night before) so you'll be prepared for success each day during the first course section. These daily expectations are designed to lower your stress and help answer any questions you might have about what you are supposed to do. Here are the expectations for the first day of the program: 
+In addition to the section objectives, you'll have daily expectations for the first section of the program. These expectations will help orientate you for the day and to provide clarity on any key concepts you'll need to focus on. We recommend looking over the daily expectations ahead of time (such as the night before) so you'll be prepared for success each day during the first course section. These daily expectations are designed to lower your stress and help answer any questions you might have about what you are supposed to do. Here are the expectations for the second day of the program (first day will be covered in orientation!): 
 
 * Full-time students: [Tuesday Schedule and Expectations](https://new.learnhowtoprogram.com/introduction-to-programming/git-html-and-css/tuesday-schedule-and-expectations).
-* Part-time students: [Tuesday Schedule and Expectations](https://new.learnhowtoprogram.com/introduction-to-programming-part-time/git-html-and-css/tuesday-schedule-and-expectations)
+* Part-time Day-time students: [Tuesday Schedule and Expectations](https://new.learnhowtoprogram.com/introduction-to-programming-part-time/git-html-and-css/tuesday-schedule-and-expectations)
+* Part-time Evening students: [Tuesday Schedule and Expectations](https://new.learnhowtoprogram.com/introduction-to-programming-part-time-evening/git-html-and-css/tuesday-schedule-and-expectations)
+* *Legacy* Full-time students: [Tuesday Schedule and Expectations](https://new.learnhowtoprogram.com/introduction-to-programming-classic/git-html-and-css/tuesday-schedule-and-expectations).
 
 Review the expectations and objectives as needed throughout the section. 

--- a/0j_independent_projects_and_code_reviews.md
+++ b/0j_independent_projects_and_code_reviews.md
@@ -26,10 +26,10 @@ The next lesson goes into detail about what you can and cannot reference, includ
 
 Keep in mind that failing projects _may be resubmitted._ (see _Resubmission_ below). If you find yourself struggling, don't feel tempted to plagiarize. Do the best you can, and submit what you have. You and your teacher can later work out a plan for revisiting and resubmitting the project. 
 
-## [Schedule for Full-Time Students](#schedule-for-full-time-students)
+## [Schedule for Full-Time and Part-Time Day Students](#schedule-for-full-time-and-part-time-day-students)
 <hr />
 
-If you are a part-time student, skip ahead to the next section.
+The following information is applicable for both full-time and part-time students who participate in classes that occur in the day-time. If you are an **evening** part-time student, you may skip ahead to the next section.
 
 Independent project prompts are published on [Epicenter](https://epicenter.epicodus.com/) each Friday at 8:00 am PST. You can find the prompt by going to the _Courses_ tab, selecting your current course, and then selecting the CR that matches the course section. 
 
@@ -37,7 +37,7 @@ Projects must be submitted through Epicenter by 5 pm PST on the same Friday it w
 
 ![This calendar shows the process for independent project submissions, reviews, and resubmissions for full-time students.](https://learnhowtoprogram.s3.us-west-2.amazonaws.com/INTRO/week1-html-css/remote_images_2021/resubmission-calendar.png)
 
-The calendar above shows the independent project process for the full-time program:
+The calendar above shows the independent project process for the full-time and part-time day programs:
 
 * Every Friday, independent projects are released at 8 am PST and submitted by 5:00 pm PST.
 * Your instructor will review your independent project in the following week. If all objectives are met, you are done!
@@ -46,10 +46,10 @@ The calendar above shows the independent project process for the full-time progr
 * If there are still incomplete objectives at that point, you'll have one more opportunity to fix any remaining problems in the project by 8:00 AM the following Monday seventeen days after the project was initially assigned.
 * If the submission is still not passing, you will likely be asked to leave the program, though you may be invited to try the program again at a later date.
 
-## [Schedule for Part-Time Students](#schedule-for-part-time-students)
+## [Schedule for Part-Time Evening Students](#schedule-for-part-time-evening-students)
 <hr />
 
-If you are a full-time student, skip ahead to the next section.
+If you are a full-time student, or a part-time day-time student, skip ahead to the next section.
 
 Independent project prompts are published on [Epicenter](https://epicenter.epicodus.com/)  on Thursdays at 8:00 am PST, every other week. You can find the prompt by going to the _Courses_ tab, selecting your current course, and then selecting the CR that matches the course section. 
 
@@ -88,7 +88,13 @@ In general, we have the following expectations for independent projects.
 
 * **The completed project must use the provided prompt.** For instance, you cannot simply create your own prompt because you do not want to work on the prompt provided. As an example, if the prompt asks you to create an application for an imaginary storefront, you cannot instead turn in a choose-your-own-adventure application, even if the completed project demonstrates understanding of the course materials.
 
-* **You must work on the project for the specified amount of time, and during the time frame allotted.** For full-time students, students are expected to work 8 hours between 8 am and 5 pm on Friday PST. For part-time students, students are expect to work 4 hours between Thursday at 8 am and the following Sunday at 8 am PST. If you need an exception (for instance, you do not have childcare or have to work during part of the allotted time), you can check in with your instructor about an alternate time to complete the prompt. Exceptions can also be granted for documented emergencies. Note that instructors may use your Git commit history (Git is a tool for tracking changes to code) to help determine whether you spent the full amount of time working on the project.
+* **You must work on the project for the specified amount of time, and during the time frame allotted.** 
+
+    - For full-time students, students are expected to work 8 hours between 8 am and 5 pm on Friday PST. 
+    - For part-time day-time students, students are expected to work 4 hours between Friday at 8 am and the following Monday at 8 am PST.
+    - For part-time evening students, students are expect to work 4 hours between Thursday at 8 am and the following Sunday at 8 am PST.
+
+    If you need an exception (for instance, you do not have childcare or have to work during part of the allotted time), you can check in with your instructor about an alternate time to complete the prompt. Exceptions can also be granted for documented emergencies. Note that instructors may use your Git commit history (Git is a tool for tracking changes to code) to help determine whether you spent the full amount of time working on the project.
 
 * **If you finish your project early, you are still expected to spend the full amount of time working on your project.** See _Further Exploration_ below. Remember that you can always add additional functionality or make an application look nicer. Even if you complete any further exploration objectives early, use the extra time to practice coding and challenge yourself further.
 
@@ -104,9 +110,9 @@ Remember, the purpose of completing these projects isn't _just_ to pass your cou
 ## [Submission](#submission)
 <hr />
 
-**For full-time students,** Independent Projects must be submitted by the end of class on Friday at 5 pm. 
+**For full-time students, and part-time day-time students,** Independent Projects must be submitted by the end of class on Friday at 5 pm. 
 
-**For part-time students,** Independent Projects must be submitted on Sunday by the start of class at 9 am. 
+**For part-time evening students,** Independent Projects must be submitted on Sunday by the start of class at 9 am. 
 
 Before submitting, do a final check for each objective.  Spend a few minutes checking indentation, removing commented-out code, creating a detailed README, etc. Your project should feel polished and complete.
 
@@ -155,9 +161,10 @@ The student handbook (an upcoming lesson in this pre-work) covers the Academic W
 
 You will work in approximately 4-person groups on a cumulative project at the end of the following courses:
 
-* Intermediate JavaScript;
-* Ruby/Rails (for students in the Ruby/Rails track);
-* C#/.NET (for students in the C#/.NET track).
+* React;
+* C#/.NET;
+
+Additionally, there will be a group-form project halfway through the Capstone course, which happens after C#/.NET.
 
 These group projects last for an entire course section. For full-time students, that means one week, and for part-time students that's two weeks. 
 

--- a/0jab_internship_coursework_and_career_reviews.md
+++ b/0jab_internship_coursework_and_career_reviews.md
@@ -52,8 +52,8 @@ Projects for the Internship course follow the same submission and resubmission s
 
 Although the dedicated time in class to work on career reviews is usually sufficient to complete a career review, some students take extra time to complete them. These are the deadlines for initial project submissions:
 
-  * **For full-time students,** career reviews must be submitted by 5 pm on Friday.
-  * **For part-time students,** career reviews must be submitted the following Sunday they are assigned at 9 am.
+  * **For full-time students, and part-time day-time** career reviews must be submitted by 5 pm on Friday.
+  * **For part-time evening students,** career reviews must be submitted the following Sunday they are assigned at 9 am.
 
 Some projects don't require a submission, like with mock interviews. In those cases, attending the mock interview at the designated time counts for your submission.
 
@@ -81,8 +81,8 @@ If you are passing objectives, there is nothing more for you to do!
 
 If your advisor finds that you are not passing an objective, they will give you feedback and ask you to complete a resubmission:
 
-  * **For full-time students,** resubmissions are due the Monday 10 days after your initial submission was due, just like with code reviews.
-  * **For part-time students,** resubmissions are due the Sunday after your initial submission was due, just like with code reviews.
+  * **For full-time students, and part-time day-time students** resubmissions are due the Monday 10 days after your initial submission was due, just like with code reviews.
+  * **For part-time evening students,** resubmissions are due the Sunday after your initial submission was due, just like with code reviews.
 
 Your advisor will review your resubmission in the following week. If you are passing objectives, there is nothing more for you to do. If there are still incomplete objectives after your advisor has reviewed your resubmission, you'll have one more opportunity to fix any remaining problems in the project by the final deadline.
 
@@ -92,8 +92,8 @@ The only exception to this resubmission timeline is the mock interview assignmen
 
 Final project deadlines are always due seventeen days after the project was initially assigned:
 
-  * For full-time students, the final deadline is at 8 am on the Monday seventeen days after the project was initially assigned.
-  * For part-time students, the final deadline is at 9 am on the Sunday seventeen days after the project was initially assigned.
+  * For full-time students, and part-time day-time students, the final deadline is at 8 am on the Monday seventeen days after the project was initially assigned.
+  * For part-time evening students, the final deadline is at 9 am on the Sunday seventeen days after the project was initially assigned.
 
 Projects submitted after the final deadline will not be accepted.
 

--- a/0k_final_capstone_project.md
+++ b/0k_final_capstone_project.md
@@ -1,4 +1,4 @@
-Students who are enrolled in our full-stack programs will brainstorm, plan, and complete a final capstone project in 40 hours of dedicated class time during the final course of the program. The capstone project coincides with the React course. The goal of the capstone is to create a portfolio-ready project which you'll be able to add to your resume, share with potential employers, and show off to friends and family!
+Students who are enrolled in our full-stack programs will brainstorm, plan, and complete a final capstone project in 120 hours of dedicated class time during the final course of the program. The capstone project will be part of the Capstone Course, which includes other materials to help prepare students for extended concepts and career development. The goal of the capstone is to create a portfolio-ready project which you'll be able to add to your resume, share with potential employers, and show off to friends and family!
 
 ## [Independent Capstone Schedule](#independent-capstone-schedule)
 
@@ -6,14 +6,10 @@ Students who are enrolled in our full-stack programs will brainstorm, plan, and 
 
 Listed below is an outline of capstone-related events that occur in the React course. The bolded titles below correspond to the names of each learning section within the React course.
 
-* **Functional Programming:** Begin brainstorming ideas, [learn about deadlines and resources](https://new.learnhowtoprogram.com/react-classic/functional-programming-with-javascript/capstone-timeline-deadlines-and-brainstorming-homework), and review the [MVP](https://new.learnhowtoprogram.com/react/functional-programming-with-javascript/capstone-planning-the-minimum-viable-product) (Minimum Viable Product).
+* **Functional Programming:** Early Capstone Planning happens during the first section of the React course. Here, you'll start brainstorming ideas and get comfortable with coming up with application ideas.
 
-* **React Fundamentals:** Narrow down your ideas for your capstone, and learn about the [capstone sign-up and proposal](https://new.learnhowtoprogram.com/react/react-fundamentals/independent-capstone-project-sign-up-and-proposal) that you will complete during the React with Redux course section.
+* **Building an API:** Narrow down your ideas for your capstone, and learn about the [MVP](https://new.learnhowtoprogram.com/react/functional-programming-with-javascript/capstone-planning-the-minimum-viable-product) (Minimum Viable Product). Teachers will be able to provide you with feedback and resources on how to accomplish your ideas, and let you know if there are any items to consider.
 
-* **React with Redux:** Share your capstone idea on a public "capstone sign-up" board (shared within your cohort). Then, your normally scheduled time to complete an independent coding project will be spent working on your capstone. As part of your first work session on your capstone, you will complete and turn in your capstone proposal. Your instructors will review your proposal and give feedback as needed.
+* **Self-Guided Study: Weeks 1-4:** You will explore extended concepts of your own choosing that will allow you to specialize in certain aspects of development that interests you. You'll be welcome to take ideas that you learn here to implement them in your capstone, or even allow your capstone idea influence what extended concepts you wish to spend time learning.
 
-* **React with NoSQL:** Your normally scheduled time to complete an independent coding project will be spent working on your capstone project.
-
-* **React with APIs:** Your normally scheduled time to complete an independent coding project will be spent working on your capstone project.
-
-* **Independent Capstone:** You will spend this entire course section working on your capstone. On the last day of class, you will present your capstone project to classmates and then turn it in as your final independent coding project.
+* **Independent Capstone: Weeks 1-3:** You will spend this entire course section working on your capstone. On the last day of class, you will present your capstone project to classmates and then turn it in as your final independent coding project.


### PR DESCRIPTION
### Change a variety of pieces:

Independent Projects and Code Reviews
- Adjust Schedule for Full-Time Students, and Schedule for Part-Time students to reflect the addition of a day-time PT cohort.
- adjust the "Group Work" section to reflect Team Week being at the end of React instead of Intermediate JavaScript.
- Update Submission section language to include part-time day language

Final Captsone Project lesson
- adjust the breakdown of the capstone schedule to reflect the changes around the React/C# swap.

Curriculum Details: Intro to Programming
- In the feedback section, replace the image of the old LHTP UI.

Attendance Policy
- Sign-in and Sign-out windows section needs an update to include pt-day language.

Internship Coursework and Career Reviews
-  Review Process & resubmissions section needs updated language for pt-day
-  Final Project Deadlines needs the same language update

Preparing for the First Week
- Course Section Objectives section needs updated links for all 4 tracks
 Daily Expectations section needs updated links, as they shouldn't go to Tuesday Schedule and Expectations, but also need them for all tracks.

Daily Schedules for All Students
- A Typical Class Day section needs updated Part-time language, perhaps just a new section for day-time part-time.

### Items still needing completion:

Student Success and Skills
- Schedules need to be updated for PT Day

Career Services Schedule
- Needs a total rewrite based on the CS changes
- Needs a full-time and a part-time version???

Internship Coursework and Career Reviews
- Assignment Schedule section: links to FT and PT CS schedules are the same information. do they need to be different information?
- Uncertain if this page needs further changes due to CS rewrites